### PR TITLE
Use ended so failed job dependents still run

### DIFF
--- a/importer/writer.py
+++ b/importer/writer.py
@@ -66,7 +66,7 @@ def create_commands(df, connections, destination):
         memory = "-M2000 -R 'select[mem>2000] rusage[mem=2000]' "
         if i >= connections:
             df.loc[i, 'Job_to_depend_on'] = df.loc[i - connections, 'Job_name']
-            df.loc[i, 'Command'] = 'bsub -o %s/%s.o -e %s/%s.e %s -J import_%s -w %s "%s && %s"' % (
+            df.loc[i, 'Command'] = 'bsub -o %s/%s.o -e %s/%s.e %s -J import_%s -w \'ended("%s")\' "%s && %s"' % (
                 destination, df.loc[i, 'Read accession'], destination, df.loc[i, 'Read accession'], memory, df.loc[i, 'Read accession'],df.loc[i, 'Job_to_depend_on'],df.loc[i,'enaDataGet_command'], df.loc[i,'extract_data_command'])
         if i< connections:
             df.loc[

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -122,7 +122,7 @@ class TestCreateCommands(unittest.TestCase):
               'enaDataGet_command':[self.ena_command_path+' -f fastq -d destination Accession1',self.ena_command_path+' -f fastq -d destination Accession2'],
               'extract_data_command':[self.mv_accession1_command,self.mv_accession2_command],
               'Command':['bsub -o destination/Accession1.o -e destination/Accession1.e '+self.memory+'  -J import_Accession1 "'+self.ena_command_path+' -f fastq -d destination Accession1 && '+self.mv_accession1_command+'"',
-                         'bsub -o destination/Accession2.o -e destination/Accession2.e '+self.memory+'  -J import_Accession2 -w import_Accession1 "'+self.ena_command_path+' -f fastq -d destination Accession2 && '+self.mv_accession2_command+'"'],
+                         'bsub -o destination/Accession2.o -e destination/Accession2.e '+self.memory+'  -J import_Accession2 -w \'ended("import_Accession1")\' "'+self.ena_command_path+' -f fastq -d destination Accession2 && '+self.mv_accession2_command+'"'],
               'Job_to_depend_on':[None,'import_Accession1']}
         expected_df = pd.DataFrame(data=d)
         pd.testing.assert_frame_equal(actual_df,expected_df)


### PR DESCRIPTION
Job dependence is being used to limit number of concurrent connections. These dependencies do not therefore require upstream jobs to get to `DONE` state; `EXIT` is also fine.

See [docs](https://www.ibm.com/support/knowledgecenter/SSWRJV_10.1.0/lsf_admin/job_dep_conditions.html) on LSF job dependency.

Relates to point 2 of [684108](https://rt.sanger.ac.uk/Ticket/Display.html?id=684108).