### PR TITLE
External import 1.0.23

### DIFF
--- a/importer/importer.py
+++ b/importer/importer.py
@@ -9,7 +9,7 @@ class DataImporter:
     def new_instance(base: str, ticket: int, database: str):
         loader_list = []
         destination = "%s/%d" % (base, ticket)
-        for index, file in enumerate(glob.glob(f"{base}/{ticket}/external_{ticket}_*.xlsx",
+        for index, file in enumerate(glob.glob(f"{base}/{ticket}/external_{ticket}_*.xls",
                                                recursive=False)):
             command = DataImporter(destination, ticket, index, database)
             loader_list.append(command)
@@ -41,7 +41,7 @@ bsub -o {command.destination}/external_{command.ticket}_{command.index}.log -e {
   -d {command.database} \\
   -f {command.destination} \\
   -p /lustre/scratch118/infgen/pathogen/pathpipe/{command.database}/seq-pipelines \\
-  {command.destination}/external_{command.ticket}_{command.index}.xlsx
+  {command.destination}/external_{command.ticket}_{command.index}.xls
 
 """)
         dependency = f"external_{command.ticket}_{command.index}"
@@ -55,7 +55,7 @@ bsub -o {command.destination}/external_{command.ticket}.%J.%I.o -e {command.dest
   -d {command.database} \\
   -f {command.destination} \\
   -p /lustre/scratch118/infgen/pathogen/pathpipe/{command.database}/seq-pipelines \\
-  {command.destination}/external_{command.ticket}_\$LSB_JOBINDEX.xlsx
+  {command.destination}/external_{command.ticket}_\$LSB_JOBINDEX.xls
 
 """)
         command_file.write("""

--- a/importer/importer.py
+++ b/importer/importer.py
@@ -3,21 +3,21 @@ import os
 
 class DataImporter:
 
-    BASE_DATA_PATH = "/lustre/scratch118/infgen/pathogen/pathpipe/external_seq_data"
+    BASE_DATA_PATH = "/lustre/scratch118/infgen/pathogen/pathpipe/external_seq_data" # Only used in tests
 
     @staticmethod
     def new_instance(base: str, ticket: int, database: str):
         loader_list = []
         destination = "%s/%d" % (base, ticket)
-        for index, file in enumerate(glob.glob(f"{DataImporter.BASE_DATA_PATH}/{ticket}/external_{ticket}_*.xlsx",
+        for index, file in enumerate(glob.glob(f"{base}/{ticket}/external_{ticket}_*.xlsx",
                                                recursive=False)):
             command = DataImporter(destination, ticket, index, database)
             loader_list.append(command)
         return loader_list
     
     @staticmethod
-    def get_complete_manifest_for_ticket(ticket: int):
-        return f"{DataImporter.BASE_DATA_PATH}/{ticket}/complete_external_{ticket}.xlsx"
+    def get_complete_manifest_for_ticket(ticket: int, base: str):
+        return f"{base}/{ticket}/complete_external_{ticket}.xlsx"
 
     def __init__(self, destination: str, ticket: int, index: int, database: str):
         self.destination = destination

--- a/importer/importer.py
+++ b/importer/importer.py
@@ -3,8 +3,6 @@ import os
 
 class DataImporter:
 
-    BASE_DATA_PATH = "/lustre/scratch118/infgen/pathogen/pathpipe/external_seq_data" # Only used in tests
-
     @staticmethod
     def new_instance(base: str, ticket: int, database: str):
         loader_list = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-et-xmlfile==1.1.0
-openpyxl==3.0.9
-xlrd==2.0.1

--- a/scripts/external-import.py
+++ b/scripts/external-import.py
@@ -50,7 +50,7 @@ def split_spreadsheet_by_breakpoint(sheet,arguments):
 
 def load(arguments: argparse.Namespace):
     # Split complete spreadsheet by breakpoint
-    complete_spreadsheet = DataImporter.get_complete_manifest_for_ticket(arguments.ticket)
+    complete_spreadsheet = DataImporter.get_complete_manifest_for_ticket(arguments.ticket, arguments.output)
     loader = SpreadsheetLoader(complete_spreadsheet)
     sheet = loader.load()
     split_spreadsheet_by_breakpoint(sheet, arguments)

--- a/scripts/external-import.py
+++ b/scripts/external-import.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+import sys
+sys.path.insert(0,"/nfs/users/nfs_p/pathpipe/mm6/external-import/")
+
 import argparse
 from sys import argv
 
@@ -9,7 +12,8 @@ from importer.loader import SpreadsheetLoader
 from importer.pfchecks import print_pf_checks
 from importer.validation import validate_spreadsheet
 from importer.writer import Preparation, \
-    OutputSpreadsheetGenerator
+    OutputSpreadsheetGeneratorXLS, \
+    OutputSpreadsheetGeneratorXLSX
 
 def validate(arguments: argparse.Namespace):
     loader = SpreadsheetLoader(arguments.spreadsheet)
@@ -25,9 +29,9 @@ def prepare(arguments: argparse.Namespace):
     loader = SpreadsheetLoader(arguments.spreadsheet)
     sheet = loader.load()
 
-    generator = OutputSpreadsheetGenerator(sheet, 0)
+    generator = OutputSpreadsheetGeneratorXLSX(sheet, 0)
     workbook, file_ended, current_position = generator.build(0, arguments.download)
-    preparation = Preparation.new_instance_complete(sheet, arguments.output, arguments.ticket)
+    preparation = Preparation.new_instance_complete(sheet, arguments.output, arguments.ticket, generator.FILE_ENDING)
     preparation.create_destination_directory()
     preparation.save_workbook(workbook)
     if arguments.download:
@@ -41,9 +45,9 @@ def split_spreadsheet_by_breakpoint(sheet,arguments):
     instance = 0
     current_position = 0
     while file_ended == False:
-        generator = OutputSpreadsheetGenerator(sheet, current_position)
+        generator = OutputSpreadsheetGeneratorXLS(sheet, current_position)
         workbook, file_ended, current_position = generator.build(arguments.breakpoint, False)
-        preparation = Preparation.new_instance(sheet, arguments.output, arguments.ticket, instance)
+        preparation = Preparation.new_instance(sheet, arguments.output, arguments.ticket, instance, generator.FILE_ENDING)
         preparation.create_destination_directory()
         preparation.save_workbook(workbook)
         instance += 1

--- a/scripts/external-import.py
+++ b/scripts/external-import.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python3
 
-import sys
-sys.path.insert(0,"/nfs/users/nfs_p/pathpipe/mm6/external-import/")
-
 import argparse
 from sys import argv
 

--- a/tests/importer_test.py
+++ b/tests/importer_test.py
@@ -13,7 +13,7 @@ COMMAND_3 = DataImporter('base/123', 123, 2, 'database')
 COMMANDS = [COMMAND_1, COMMAND_2, COMMAND_3]
 
 def glob_replacer(ticket_string, recursive):
-    if ticket_string != f'{DataImporter.BASE_DATA_PATH}/{TICKET}/external_{TICKET}_*.xlsx':
+    if ticket_string != f'{OUTPUT}/{TICKET}/external_{TICKET}_*.xls':
         raise Exception('Ticket lost in transfer.')
     elif recursive != False:
         raise Exception('Recursive not set to false.')
@@ -31,7 +31,7 @@ class importerTesting(unittest.TestCase):
                 self.assertEqual(CREATED_COMMAND.database, COMMANDS[MATCHING_COMMAND].database)
                 self.assertEqual(CREATED_COMMAND.ticket, COMMANDS[MATCHING_COMMAND].ticket)
                 self.assertEqual(CREATED_COMMAND.index, COMMANDS[MATCHING_COMMAND].index)
-            glob_mock.assert_called_once_with(f'{DataImporter.BASE_DATA_PATH}/123/external_123_*.xlsx', recursive=False)
+            glob_mock.assert_called_once_with(f'{OUTPUT}/123/external_123_*.xls', recursive=False)
 
 
     def test_importer_printout(self):
@@ -45,7 +45,7 @@ class importerTesting(unittest.TestCase):
             f'  -d {DATABASE} \\\n',
             f'  -f {OUTPUT}/{TICKET} \\\n',
             f'  -p /lustre/scratch118/infgen/pathogen/pathpipe/{DATABASE}/seq-pipelines \\\n',
-            f"  {OUTPUT}/{TICKET}/external_{TICKET}_0.xlsx\n",
+            f"  {OUTPUT}/{TICKET}/external_{TICKET}_0.xls\n",
             '\n',
             '\n',
             f'bsub -o {OUTPUT}/{TICKET}/external_{TICKET}.%J.%I.o -e {OUTPUT}/{TICKET}/external_{TICKET}.%J.%I.e -M2000 \\\n',
@@ -55,7 +55,7 @@ class importerTesting(unittest.TestCase):
             f'  -d {DATABASE} \\\n',
             f'  -f {OUTPUT}/{TICKET} \\\n',
             f'  -p /lustre/scratch118/infgen/pathogen/pathpipe/{DATABASE}/seq-pipelines \\\n',
-            f"  {OUTPUT}/{TICKET}/external_{TICKET}_\$LSB_JOBINDEX.xlsx\n",
+            f"  {OUTPUT}/{TICKET}/external_{TICKET}_\$LSB_JOBINDEX.xls\n",
             '\n',
             '\n',
             '# Then following the external data import SOP to register the study\n',
@@ -81,7 +81,7 @@ class importerTesting(unittest.TestCase):
             f'  -d {DATABASE} \\\n',
             f'  -f {OUTPUT}/{TICKET} \\\n',
             f'  -p /lustre/scratch118/infgen/pathogen/pathpipe/{DATABASE}/seq-pipelines \\\n',
-            f"  {OUTPUT}/{TICKET}/external_{TICKET}_0.xlsx\n",
+            f"  {OUTPUT}/{TICKET}/external_{TICKET}_0.xls\n",
             '\n',
             '\n',
             f'bsub -o {OUTPUT}/{TICKET}/external_{TICKET}.%J.%I.o -e {OUTPUT}/{TICKET}/external_{TICKET}.%J.%I.e -M2000 \\\n',
@@ -91,7 +91,7 @@ class importerTesting(unittest.TestCase):
             f'  -d {DATABASE} \\\n',
             f'  -f {OUTPUT}/{TICKET} \\\n',
             f'  -p /lustre/scratch118/infgen/pathogen/pathpipe/{DATABASE}/seq-pipelines \\\n',
-            f"  {OUTPUT}/{TICKET}/external_{TICKET}_\$LSB_JOBINDEX.xlsx\n",
+            f"  {OUTPUT}/{TICKET}/external_{TICKET}_\$LSB_JOBINDEX.xls\n",
             '\n',
             '\n',
             '# Then following the external data import SOP to register the study\n',
@@ -117,7 +117,7 @@ class importerTesting(unittest.TestCase):
             f'  -d {DATABASE} \\\n',
             f'  -f {OUTPUT}/{TICKET} \\\n',
             f'  -p /lustre/scratch118/infgen/pathogen/pathpipe/{DATABASE}/seq-pipelines \\\n',
-            f"  {OUTPUT}/{TICKET}/external_{TICKET}_0.xlsx\n",
+            f"  {OUTPUT}/{TICKET}/external_{TICKET}_0.xls\n",
             '\n',
             '\n',
             '# Then following the external data import SOP to register the study\n',

--- a/tests/writer_test.py
+++ b/tests/writer_test.py
@@ -4,7 +4,7 @@ import os
 import xlrd
 import openpyxl
 from importer.model import Spreadsheet, RawRead
-from importer.writer import Preparation, OutputSpreadsheetGenerator, create_commands, submit_commands
+from importer.writer import Preparation, OutputSpreadsheetGeneratorXLS, OutputSpreadsheetGeneratorXLSX, create_commands, submit_commands
 import pandas as pd
 from testfixtures import TempDirectory
 
@@ -23,7 +23,7 @@ class TestFileCopy(unittest.TestCase):
             RawRead(forward_read='PAIR1_1.fastq.gz', reverse_read='PAIR1_2.fastq.gz', sample_name='SAMPLE1',
                     taxon_id='1280', library_name='LIB1', sample_accession=None),
             RawRead(forward_read='PAIR2_1.fastq.gz', reverse_read='PAIR2_2.fastq.gz', sample_name='SAMPLE2',
-                    taxon_id='1280', library_name='LIB2', sample_accession=None)]), 'destination', 0, 0)
+                    taxon_id='1280', library_name='LIB2', sample_accession=None)]), 'destination', 0, 0, "xlsx")
         under_test.copy_files('source')
         self.assertEqual(copyfile_patch.call_args_list,
                           [call('source/PAIR1_1.fastq.gz', 'destination/0/PAIR1_1.fastq.gz'),
@@ -37,7 +37,7 @@ class TestFileCopy(unittest.TestCase):
             RawRead(forward_read='PAIR1_1.fastq.gz', reverse_read='PAIR1_2.fastq.gz', sample_name='SAMPLE1',
                     taxon_id='1280', library_name='LIB1', sample_accession=None),
             RawRead(forward_read='SINGLE.fastq.gz', reverse_read=None, sample_name='SAMPLE2',
-                    taxon_id='1280', library_name='LIB2', sample_accession=None)]), 'destination', 0, 0)
+                    taxon_id='1280', library_name='LIB2', sample_accession=None)]), 'destination', 0, 0, "xlsx")
         under_test.copy_files('source')
         self.assertEqual(copyfile_patch.call_args_list,
                           [call('source/PAIR1_1.fastq.gz', 'destination/0/PAIR1_1.fastq.gz'),
@@ -53,21 +53,22 @@ class TestFileDownload(unittest.TestCase):
         self.tempdir.write('2/Accession1_2.fastq.gz',b'the text')
         self.tempdir_path = self.tempdir.path
         print('temp',self.tempdir_path)
+        excel_type="xlsx"
         self.under_test1 = Preparation.new_instance(Spreadsheet.new_instance("MyStudy", [
             RawRead(forward_read='Accession1', reverse_read='T', sample_name='SAMPLE1',
                     taxon_id='1280', library_name='LIB1', sample_accession=None),
             RawRead(forward_read='Accession2', reverse_read='T', sample_name='SAMPLE2',
-                    taxon_id='1280', library_name='LIB2', sample_accession=None)]), self.tempdir_path, 0, 0)
+                    taxon_id='1280', library_name='LIB2', sample_accession=None)]), self.tempdir_path, 0, 0, excel_type)
         self.under_test2 = Preparation.new_instance(Spreadsheet.new_instance("MyStudy", [
             RawRead(forward_read='Accession1', reverse_read='T', sample_name='SAMPLE1',
                     taxon_id='1280', library_name='LIB1', sample_accession=None),
             RawRead(forward_read='Accession2', reverse_read='T', sample_name='SAMPLE2',
-                    taxon_id='1280', library_name='LIB2', sample_accession=None)]), self.tempdir_path, 1, 0)
+                    taxon_id='1280', library_name='LIB2', sample_accession=None)]), self.tempdir_path, 1, 0, excel_type)
         self.under_test3 = Preparation.new_instance(Spreadsheet.new_instance("MyStudy", [
             RawRead(forward_read='Accession1', reverse_read='T', sample_name='SAMPLE1',
                     taxon_id='1280', library_name='LIB1', sample_accession=None),
             RawRead(forward_read='Accession2', reverse_read='T', sample_name='SAMPLE2',
-                    taxon_id='1280', library_name='LIB2', sample_accession=None)]), self.tempdir_path, 2, 0)
+                    taxon_id='1280', library_name='LIB2', sample_accession=None)]), self.tempdir_path, 2, 0, excel_type)
 
     def tearDown(self):
         self.tempdir.cleanup()
@@ -233,7 +234,7 @@ class TestXlsGeneration(unittest.TestCase):
                                      BREAKPOINT_FIRSTSHEET.cell_value(row, col))
 
     def run_function(self, sheet):
-        generator = OutputSpreadsheetGenerator(sheet, A_POSITION)
+        generator = OutputSpreadsheetGeneratorXLSX(sheet, A_POSITION)
         workbook, file_ended, current_position = generator.build(A_BREAKPOINT, False)
         workbook.save('workbook.xlsx')
         self.assertEqual((current_position, file_ended), (2, True))
@@ -261,7 +262,7 @@ class TestXlsGeneration(unittest.TestCase):
 
     def test_of_preparation_initialization(self):
         spreadsheet = Spreadsheet()
-        preparation = Preparation.new_instance(spreadsheet, AN_OUTPUT, A_TICKET, AN_INSTANCE)
+        preparation = Preparation.new_instance(spreadsheet, AN_OUTPUT, A_TICKET, AN_INSTANCE, "xlsx")
         self.assert_preparation(preparation, spreadsheet)
 
     def assert_preparation(self, preparation, spreadsheet):


### PR DESCRIPTION
This re-implements XLS writing. Since the output Excel file from `prepare` is read in again, and that read is using XSLX, it is written as XLSX. The output Excel file(s) from `load` are written as XLS, to maintain compatibility with `update-pipeline`.

Also removing a dependency on hardcoded path (kept for tests).